### PR TITLE
fixed -dump syntax

### DIFF
--- a/src/usersguide/customizing.sgml
+++ b/src/usersguide/customizing.sgml
@@ -161,7 +161,7 @@ multiples files), the last
 one read is the value of the configuration variable.  
 One can dump all of the current configuration values on a running 
 Condor pool using the command.
-<computeroutput>condor_config_val --dump</computeroutput>. 
+<computeroutput>condor_config_val -dump</computeroutput>. 
 The configuration directory itself, is located in 
 <computeroutput>/opt/condor/etc/config.d</computeroutput>. Within that directory, Rocks creates two 
 configuration files


### PR DESCRIPTION
Hello,

My first pull request so please excuse the minuteness of my change.
The flags for "condor_config_val" require one minus sign not two.

-Chris 
